### PR TITLE
Fix manual chapter markers ignored during m4b generation

### DIFF
--- a/tts_audiobook_tool/sound/m4b_chapter_util.py
+++ b/tts_audiobook_tool/sound/m4b_chapter_util.py
@@ -60,6 +60,23 @@ def make_output_sections(project: Project, index_start: int, index_end: int) -> 
     Returns Book sections overlapping the inclusive phrase-group output range as
     tuples of absolute start index, absolute end index (exclusive), and title.
     """
+    if project.markers:
+        # Use manual markers if they exist
+        starts = [0, *sorted(list(set(project.markers)))]
+        result: list[tuple[int, int, str]] = []
+        for i, start in enumerate(starts):
+            end = starts[i + 1] if i + 1 < len(starts) else len(project.book.phrase_groups)
+            
+            # Use the segment text as the chapter title
+            title = f"Chapter {i+1}"
+            if start < len(project.book.phrase_groups):
+                title = project.book.phrase_groups[start].text
+            
+            overlaps = start <= index_end and end > index_start
+            if overlaps:
+                result.append((start, end, title))
+        return result
+
     sections = project.book.sections
     if len(sections) <= 1:
         return []


### PR DESCRIPTION
## Problem

The issue occurred because the function responsible for generating chapters in the `.m4b` file completely ignored the manual section markers defined by the user (common when using plain text as the source).

### Root Cause

In `m4b_chapter_util.py`, the `make_output_sections` function relied exclusively on the automatically generated sections (`project.book.sections`). Although manual section markers are stored in the `markers` field of `project.json`, the function never checked this field. As a result, when users created chapters manually, the generated `.m4b` metadata either contained incorrect chapter boundaries or failed to reflect the intended chapter structure.

### Solution

The `make_output_sections` logic was updated to prioritize manual markers whenever they are available.

* **Manual Marker Priority:** The function now checks for `project.markers` first. If manual markers exist, they are used as the chapter boundaries.
* **Dynamic Chapter Titles:** For each manual marker, the function retrieves the corresponding sentence from `project.book.phrase_groups` and uses its text as the chapter title.
* **Fallback Behavior:** If no manual markers are present, the original behavior is preserved, using the automatically generated sections and their titles.

With this change, chapter boundaries in the generated `.m4b` file now accurately match the user's manually defined markers while maintaining full backward compatibility for projects that rely on automatic section generation.

Fixes zeropointnine/tts-audiobook-tool#29