### PR TITLE
Fix textual terminal detection on Windows

### DIFF
--- a/tts_audiobook_tool/textual/textual_shared.py
+++ b/tts_audiobook_tool/textual/textual_shared.py
@@ -119,16 +119,11 @@ def load_css(*filenames: str) -> str:
     )
 
 def can_textual() -> bool:
-    """ Coarse test to see if terminal can support a full-screen interface. """
-
-    from tts_audiobook_tool.ask import can_hotkey
-
-    if not can_hotkey:
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False
 
-    term = os.environ.get("TERM", "")
-    return (
-        sys.stdin.isatty()
-        and sys.stdout.isatty()
-        and term not in {"", "dumb"}
-    )
+    if os.name != "nt":
+        term = os.environ.get("TERM", "")
+        return term not in {"", "dumb"}
+
+    return True

--- a/tts_audiobook_tool/textual/textual_shared.py
+++ b/tts_audiobook_tool/textual/textual_shared.py
@@ -119,11 +119,18 @@ def load_css(*filenames: str) -> str:
     )
 
 def can_textual() -> bool:
+    """Coarse test to see if terminal can support a full-screen interface."""
+
+    from tts_audiobook_tool.ask import can_hotkey
+
+    if not can_hotkey:
+        return False
+
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         return False
 
-    if os.name != "nt":
-        term = os.environ.get("TERM", "")
-        return term not in {"", "dumb"}
+    if os.name == "nt":
+        return True
 
-    return True
+    term = os.environ.get("TERM", "")
+    return term not in {"", "dumb"}


### PR DESCRIPTION
On Windows, TERM is typically unset in both Command Prompt and PowerShell, causing can_textual() to incorrectly reject terminals that fully support Textual. This change removes the Unix-specific TERM check on Windows while preserving the existing behavior on Unix-like systems.