### PR TITLE
Add in-place line editing to the Text Editor

### DIFF
--- a/tests/test_text_editor.py
+++ b/tests/test_text_editor.py
@@ -2,7 +2,7 @@ import asyncio
 from pathlib import Path
 
 from rich.text import Text
-from textual.widgets import Button, Input, OptionList, Static
+from textual.widgets import Button, Input, OptionList, Static, TextArea
 
 import tts_audiobook_tool.textual.text_editor as text_editor_module
 from tts_audiobook_tool.app_types import Book, BookSection
@@ -935,5 +935,360 @@ def test_confirm_surfaces_commit_error_without_mutating_project(monkeypatch) -> 
 
         assert [item.text for item in project.phrase_groups] == ["One.", "Two."]
         assert app.return_value == EditorSaveFailed("Save failed: disk full")
+
+    run(exercise())
+
+
+# =============================================================================
+# Text Editing Tests (Phase 2)
+# =============================================================================
+
+
+async def edit_first_line_to(pilot, app: "TextEditor", new_text: str) -> None:
+    """Open the editor for the currently selected line, replace its content, and confirm.
+
+    Sets the TextArea's text directly instead of simulating keystroke-by-keystroke
+    typing: this exercises the edit-confirm flow rather than Textual's own input
+    handling, and avoids accidentally typing key *names* (e.g. "enter") as literal
+    characters instead of pressing them.
+
+    Assumes the caller has already positioned selected_index where the edit
+    should happen (the OptionList selects index 0 by default on load, so most
+    callers don't need to press anything first).
+    """
+    await pilot.press("e")
+    text_area = app.query_one("#edit-area", TextArea)
+    text_area.text = new_text
+    await pilot.pause()
+    await pilot.press("ctrl+enter")
+    await pilot.pause()
+
+
+def test_edit_simple_line() -> None:
+    """Test 1: Simple edit (without \\n)."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Hello world."),
+                    make_phrase_group("Goodbye world."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            # Content is loaded via call_after_refresh() after on_mount
+            await pilot.pause()
+            assert app.list_items is not None
+            assert app.list_items != []
+            # OptionList initializes with selected_index = 0
+            assert app.selected_index == 0
+
+            await edit_first_line_to(pilot, app, "Hello world! This is a test.")
+
+            # Verify that the widget was removed
+            assert app.editor_widget is None
+            assert app.is_editing is False
+
+            # Verify that has_changes is True
+            assert app.has_changes is True
+
+            # Verify that the text appears correctly in the interface
+            assert "This is a test" in str(app.format_line(0))
+
+    run(exercise())
+
+
+def test_edit_multiline_text() -> None:
+    """Test 2: Edit containing \\n (multiple lines)."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Line 1.\nLine 2.\nLine 3."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await edit_first_line_to(
+                pilot, app, "Line 1.\nLine 2.\nLine 3.\nLine 4.\nLine 5."
+            )
+
+            # Verify that the widget was removed
+            assert app.editor_widget is None
+            assert app.is_editing is False
+
+            # Verify that has_changes is True
+            assert app.has_changes is True
+
+            # Verify that the text appears correctly with \n
+            formatted = str(app.format_line(0))
+            assert "Line 4." in formatted
+            assert "Line 5." in formatted
+
+    run(exercise())
+
+
+def test_edit_cancel_with_escape() -> None:
+    """Test 3: ESC discards the in-progress edit without changing state."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Hello world."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            # Select the first line
+            await pilot.press("down")
+            assert app.selected_index == 0
+
+            # Start editing
+            await pilot.press("e")
+            assert app.editor_widget is not None
+            assert app.is_editing is True
+
+            # Change the content, but cancel instead of confirming
+            text_area = app.query_one("#edit-area", TextArea)
+            text_area.text = "This edit should never be saved."
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # Verify that the widget was removed
+            assert app.editor_widget is None
+            assert app.is_editing is False
+
+            # Verify that nothing was staged, and original text is untouched
+            assert app.has_changes is False
+            assert "Hello world." in str(app.format_line(0))
+
+    run(exercise())
+
+
+def test_edit_confirming_empty_text() -> None:
+    """Test 4: Confirming an edit with empty text closes the editor cleanly.
+
+    NOTE: this only pins down that the editor doesn't crash or get stuck when
+    confirmed with an empty TextArea. Whether an empty phrase group should be
+    dropped, kept, or rejected outright is a product decision the app itself
+    should encode (e.g. via validation before ctrl+enter is accepted) — verify
+    the exact expectation against the current app behavior and tighten this
+    assertion (e.g. checking edit_session.phrase_groups) if the app defines one.
+    """
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Hello world."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await edit_first_line_to(pilot, app, "")
+
+            # Verify that the widget was removed and editing state was exited
+            # cleanly, regardless of how the app chose to handle empty content.
+            assert app.editor_widget is None
+            assert app.is_editing is False
+
+    run(exercise())
+
+
+def test_edit_blocked_on_section_item() -> None:
+    """Test 5: Attempt to edit TextEditorSectionItem (should be blocked)."""
+    project = make_project(
+        [
+            BookSection(
+                title="Section 1",
+                phrase_groups=[make_phrase_group("Line 1.")],
+            ),
+            BookSection(
+                title="Section 2",
+                phrase_groups=[make_phrase_group("Line 2.")],
+            ),
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            # Select the section (not a line)
+            await pilot.press("down")  # Go to the first line
+            await pilot.press("up")    # Go back to the section
+            assert app.selected_index == 0
+            assert isinstance(app.list_items[0], TextEditorSectionItem)
+
+            # Try to edit - should be blocked
+            await pilot.press("e")
+            await pilot.pause()
+
+            # The widget should not have been created
+            assert app.editor_widget is None
+            assert app.is_editing is False
+
+    run(exercise())
+
+
+def test_edit_creates_has_changes() -> None:
+    """Test 6: has_changes after confirming an edit."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Original text."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await edit_first_line_to(pilot, app, "Modified")
+
+            assert app.has_changes is True
+
+    run(exercise())
+
+
+def test_edit_preserves_voice_index() -> None:
+    """Test 7: Preservation of voice_index."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    PhraseGroup(
+                        phrases=[Phrase("Original.", Reason.SENTENCE)],
+                        voice_index=42,
+                    ),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await edit_first_line_to(pilot, app, "Modified")
+
+            item = app.list_items[0]
+            assert isinstance(item, TextEditorPhraseGroupItem)
+            assert item.phrase_group.voice_index == 42
+
+    run(exercise())
+
+
+def test_edit_single_line_edit_receives_Reason_SENTENCE() -> None:
+    """Test 8: A single-line edit (no trailing line breaks) receives Reason.SENTENCE.
+
+    Reason is always recomputed from the edited text's own trailing line
+    breaks (see update_phrase_group_text docstring) - it is never preserved
+    from before the edit. Zero trailing breaks -> Reason.SENTENCE.
+    """
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Original text."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await edit_first_line_to(pilot, app, "Modified")
+
+            item = app.list_items[0]
+            assert isinstance(item, TextEditorPhraseGroupItem)
+            for phrase in item.phrase_group.phrases:
+                assert phrase.reason == Reason.SENTENCE, (
+                    f"Expected Reason.SENTENCE, got {phrase.reason}"
+                )
+
+    run(exercise())
+
+
+def test_edit_confirm_without_changes_is_noop() -> None:
+    """Test 9: Confirming without touching the text registers no change."""
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Hello world."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await pilot.press("down")
+            await pilot.press("e")
+            assert app.is_editing is True
+
+            # Confirm without editing the TextArea content at all
+            await pilot.press("ctrl+enter")
+            await pilot.pause()
+
+            assert app.editor_widget is None
+            assert app.is_editing is False
+            assert app.has_changes is False
+            assert "Hello world." in str(app.format_line(0))
+
+    run(exercise())
+
+
+def test_edit_confirm_mixed_line_endings_is_noop() -> None:
+    """Test 10: Mixed \\r\\n/\\n in stored text still confirms as no-op.
+
+    Regression test for the TextArea \\n -> \\r\\n coalescing bug: a phrase
+    group whose raw text already mixes \\r\\n and \\n (e.g. from a
+    mixed-origin import) must not be falsely detected as "changed" just
+    because the TextArea widget normalizes line terminators on load.
+    """
+    project = make_project(
+        [
+            BookSection(
+                phrase_groups=[
+                    make_phrase_group("Line 1.\r\nLine 2.\nLine 3."),
+                ]
+            )
+        ]
+    )
+    app = make_loaded_editor(project)
+
+    async def exercise() -> None:
+        async with app.run_test() as pilot:
+            await pilot.press("down")
+            await pilot.press("e")
+            assert app.is_editing is True
+
+            # Confirm without editing the TextArea content at all
+            await pilot.press("ctrl+enter")
+            await pilot.pause()
+
+            assert app.editor_widget is None
+            assert app.is_editing is False
+            assert app.has_changes is False
 
     run(exercise())

--- a/tts_audiobook_tool/app_support/app_text.py
+++ b/tts_audiobook_tool/app_support/app_text.py
@@ -91,6 +91,18 @@ def massage_post_normalize(text: str) -> str:
     return text
 
 
+def normalize_line_terminators(text: str) -> str:
+    """
+    Converts "\\r\\n" and lone "\\r" to "\\n".
+
+    Used to normalize text before/around the TextArea widget, which
+    round-trips pure "\\n" text unchanged but coalesces a *mixed* "\\r\\n"/"\\n"
+    string into all "\\r\\n" — so text containing a mix must be normalized
+    to pure "\\n" first to keep the pre/post-edit comparison stable.
+    """
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 def split_raw_word(raw_word: str) -> tuple[str, str, str]:
     """
     Separates word into three parts.

--- a/tts_audiobook_tool/text_ops/text_edit_session.py
+++ b/tts_audiobook_tool/text_ops/text_edit_session.py
@@ -266,3 +266,145 @@ class TextEditSession:
                 )
 
         return TextEditMutationResult()
+
+    def update_phrase_group_text(
+        self,
+        item_id: int,
+        new_text: str,
+    ) -> TextEditMutationResult:
+        """Edit the text of a phrase group, preserving structure where possible.
+
+        Preserves:
+        - voice_index of the PhraseGroup
+        - Line breaks the user typed (e.g. Shift+Enter), encoded the same way
+        automatic segmentation encodes them: as trailing "\\n" characters on
+        a Phrase's text, not as separate empty-text Phrases.
+        - The reason each resulting phrase would have received had it come
+        from automatic segmentation, derived from its trailing line-break
+        count via the same convention phrase_segmenter.py uses for the last
+        phrase of a sentence (0 -> SENTENCE, 1-2 -> PARAGRAPH, 3+ ->
+        SPACE_BREAK). Reason.PHRASE never applies here, since manual edits
+        don't go through the delimiter-based sub-splitting (commas,
+        semicolons, parentheses, etc.) that produces it - every line here is
+        effectively the sole/last phrase of its own sentence.
+
+        Does NOT preserve:
+        - The exact original reason of a phrase whose text didn't change
+        (e.g. SECTION_BREAK from an EPUB import): a free-form text edit
+        can't reliably tell which lines are untouched, so reason is always
+        recomputed from the edited text's own trailing line breaks.
+        - The number of phrases (one per non-blank line): a line exceeding
+        the project's max_words_per_segment is split into multiple phrases,
+        matching how automatic segmentation enforces the same limit
+        elsewhere in the app.
+        """
+        from tts_audiobook_tool.app_types.phrase import Phrase, Reason
+        from tts_audiobook_tool.app_support import app_text
+
+        for section in self.sections:
+            for staged_phrase_group in section.phrase_groups:
+                if staged_phrase_group.item_id != item_id:
+                    continue
+
+                # Preserve the original PhraseGroup voice_index
+                voice_index = staged_phrase_group.phrase_group.voice_index
+
+                # Split the edited text into lines, keeping line terminators
+                # attached instead of discarding them. keepends=False would
+                # silently drop every "\n" the user typed (e.g. a single
+                # trailing Shift+Enter would vanish entirely and go
+                # undetected by has_changes), and PhraseGroup.text later
+                # concatenates phrase texts with no separator, so a dropped
+                # "\n" also means separate lines get jammed together with
+                # nothing between them once the phrase group is reloaded.
+                raw_lines = new_text.splitlines(keepends=True)
+
+                # Fold a blank line (pure "\n" / "\r\n") onto the end of the
+                # previous line's text instead of turning it into its own
+                # empty-text Phrase. This mirrors how automatic segmentation
+                # encodes a paragraph/section break as trailing "\n"
+                # characters on one Phrase's text (see the "p"/"x"/"xx"
+                # reason codes) rather than as a separate empty Phrase - so
+                # e.g. two trailing Shift+Enters produce one Phrase ending in
+                # "\n\n", not a second Phrase with text "".
+                merged_lines: list[str] = []
+                for raw_line in raw_lines:
+                    is_blank_line = raw_line.strip("\r\n") == ""
+                    if is_blank_line and merged_lines:
+                        merged_lines[-1] += raw_line
+                    else:
+                        merged_lines.append(raw_line)
+
+                # Build new Phrases. massage_post_normalize() collapses all
+                # \s+ (which includes "\n"), so it is applied only to each
+                # line's non-whitespace content and the trailing whitespace
+                # (line terminator) is reattached afterward, unmodified, to
+                # avoid stripping the break back out.
+                #
+                # reason is derived the same way phrase_segmenter.py derives
+                # it for the last phrase of a sentence: by the number of
+                # trailing line breaks on the *original* (pre-normalize)
+                # line, since normalization would erase that count.
+                built_phrases: list[Phrase] = []
+                for line in merged_lines:
+                    content = line.rstrip()
+                    trailing_whitespace = line[len(content):]
+
+                    num_lf = app_text.num_trailing_line_breaks(line)
+                    match num_lf:
+                        case 0:
+                            reason = Reason.SENTENCE
+                        case 1:
+                            reason = Reason.PARAGRAPH
+                        case 2:
+                            reason = Reason.PARAGRAPH
+                        case _:  # >= 3
+                            reason = Reason.SPACE_BREAK
+
+                    built_phrases.append(
+                        Phrase(
+                            app_text.massage_post_normalize(content) + trailing_whitespace,
+                            reason,
+                        )
+                    )
+
+                # Guard against an empty result: always keep at least one
+                # (possibly empty) phrase so the phrase group stays valid.
+                # There is no trailing-line-break information to classify
+                # here, so this synthetic phrase falls back to UNDEFINED.
+                if not built_phrases:
+                    built_phrases.append(Phrase("", Reason.UNDEFINED))
+
+                # Enforce the project's configured segment length. Phrases
+                # within the limit (including the empty-text guard above) pass
+                # through unchanged; oversized ones are split using the same
+                # word-count logic the app already uses for automatic
+                # segmentation, so manually edited text stays consistent with
+                # how the rest of the app defines "one segment". A falsy
+                # max_words (e.g. None or 0) disables the limit entirely.
+                max_words = self.segmentation_settings.max_words_per_segment
+                new_phrases: list[Phrase] = []
+                for phrase in built_phrases:
+                    if max_words and phrase.num_words > max_words:
+                        from tts_audiobook_tool.text_ops.phrase_segmenter import PhraseSegmenter
+
+                        new_phrases.extend(
+                            PhraseSegmenter.long_phrase_to_phrases(phrase, max_words)
+                        )
+                    else:
+                        new_phrases.append(phrase)
+
+                # Replace all phrases with the newly built ones
+                staged_phrase_group.phrase_group = PhraseGroup(
+                    phrases=new_phrases,
+                    voice_index=voice_index,
+                )
+
+                self.record_affected_index(staged_phrase_group.original_index)
+                return TextEditMutationResult(
+                    changed=True,
+                    focus_item_id=item_id,
+                    earliest_affected_original_index=staged_phrase_group.original_index,
+                )
+
+        return TextEditMutationResult()

--- a/tts_audiobook_tool/textual/content_textual_app.py
+++ b/tts_audiobook_tool/textual/content_textual_app.py
@@ -527,6 +527,13 @@ class ContentTextualApp(App[EditorClosed | EditorResultT], Generic[EditorResultT
 
     def action_open_find(self) -> None:
         """Open find at the current row, retaining and selecting its query."""
+        # Guard against opening find while a concrete editor is mid-edit (e.g.
+        # TextEditor's in-place line editing). This binding is registered with
+        # priority=True, so it is resolved by the App before a subclass's
+        # on_key handler ever sees the key event - a local prevent_default()
+        # there is not enough to stop it.
+        if getattr(self, "is_editing", False):
+            return
         find_input = self.query_one("#find-input", Input)
         if not self.find_active:
             self.find_active = True
@@ -650,6 +657,8 @@ class ContentTextualApp(App[EditorClosed | EditorResultT], Generic[EditorResultT
 
     def action_select_all(self) -> None:
         """Select every visible row while retaining the current row as anchor."""
+        if getattr(self, "is_editing", False):
+            return  # prevents ctrl+a from selecting all segments outside the TextArea
         if self.find_active:
             self.query_one("#find-input", Input).select_all()
             return

--- a/tts_audiobook_tool/textual/text_editor.py
+++ b/tts_audiobook_tool/textual/text_editor.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from typing import ClassVar
 
+from textual import events
 from textual.binding import Binding, BindingType
+from textual.widgets import TextArea as BaseTextArea
 
 from tts_audiobook_tool.app_support import app_text
 from tts_audiobook_tool.app_types.phrase import PhraseGroup
@@ -26,12 +28,26 @@ from tts_audiobook_tool.textual.phrase_group_split_dialog import (
 from tts_audiobook_tool.textual.save_changes_dialog import SaveChangesDialog
 from tts_audiobook_tool.textual.textual_shared import (
     HangingIndentText,
+    NonWrappingOptionList,
     OptionReconcileItem,
     STYLE_DIM,
 )
 
 
 SHOW_NEWLINE_CHARS = True
+
+# Headers reused between normal mode and manual line editing mode.
+_HEADER_LINES_DEFAULT = [
+    f"{COL_ACCENT}View/edit text",
+    f"{COL_DIM}- Navigation keys: [UP], [DOWN], [PAGE UP/DOWN], [HOME/END]  - [CTRL-F] Find text",
+    f"{COL_DIM}- Select multiple lines: [SHIFT] + navigation keys  - [CTRL-A] Select all  - [M] Enter manually",
+    f"{COL_DIM}- Press [{COL_ACCENT}X{COL_DIM}] to delete selected lines   [S] Split line   [E] Edit line",
+    f"{COL_DIM}- Press [ESC] to finish",
+]
+_HEADER_LINES_EDITING = [
+    f"{COL_ACCENT}View/edit text",
+    f"{COL_DIM}- Press [{COL_ACCENT}CTRL+ENTER{COL_DIM}] to confirm   [{COL_ACCENT}ESC{COL_DIM}] to cancel",
+]
 
 
 @dataclass
@@ -76,10 +92,25 @@ TextEditorListItem = TextEditorSectionItem | TextEditorPhraseGroupItem
 
 
 class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
+
+    CSS = ContentTextualApp.CSS + """
+    TextArea .text-area--selection {
+        color: $text;
+        background: $accent 60%;
+    }
+
+    #edit-area {
+        border: round #ffaa44;
+    }
+    """
+
     BINDINGS: ClassVar[list[BindingType]] = [
         *ContentTextualApp.BINDINGS,
         Binding("x", "delete_phrase_groups", show=False),
         Binding("s", "split_phrase_group", show=False),
+        Binding("e", "edit_current_line", show=False),
+        Binding("escape", "cancel_edit", show=False, priority=True),
+        Binding("ctrl+enter", "confirm_edit", show=False, priority=True),
     ]
 
     def __init__(self, project: Project) -> None:
@@ -87,16 +118,16 @@ class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
         self.edit_session_or_none: TextEditSession | None = None
         self.section_items: list[TextEditorSectionItem] = []
         self.list_items: list[TextEditorListItem] = []
-        header_lines = [
-            f"{COL_ACCENT}View/edit text",
-            f"{COL_DIM}- Navigation keys: [UP], [DOWN], [PAGE UP/DOWN], [HOME/END]  - [CTRL-F] Find text",
-            f"{COL_DIM}- Select multiple lines: [SHIFT] + navigation keys  - [CTRL-A] Select all  - [M] Enter manually",
-            f"{COL_DIM}- Press [{COL_ACCENT}X{COL_DIM}] to delete selected lines   [S] Split line",
-            f"{COL_DIM}- Press [ESC] to finish",
-        ]
+
+        # State of manual line editing (in-place with TextArea).
+        self.editor_widget: BaseTextArea | None = None
+        self.is_editing = False
+        self.editing_index: int | None = None
+        self._edit_original_text: str | None = None
+
         super().__init__(
             project,
-            header_lines,
+            list(_HEADER_LINES_DEFAULT),
             empty_state_text="No text lines",
             loading_state_text="...",
         )
@@ -189,7 +220,7 @@ class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
         return newline_token.join(presentable_lines)
 
     def format_line(self, index: int) -> HangingIndentText:
-        """Format one row, styling selected rows except for the active row."""
+        """Format one row, styling selected/found/edited rows except headings."""
         item_index = self.phrase_indices[index]
         list_item = self.list_items[item_index]
 
@@ -197,7 +228,13 @@ class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
             return self.format_section_list_item(list_item.display_text, index)
         else:
             is_find_match = index == self.find_match_index
-            style = f"{STYLE_DIM} reverse" if is_find_match else ""
+            is_being_edited = self.is_editing and index == self.editing_index
+            if is_find_match:
+                style = f"{STYLE_DIM} reverse"
+            elif is_being_edited:
+                style = "reverse"
+            else:
+                style = ""
             prefix_text = f"{list_item.ordinal:05d}  "
             presentable_text = (
                 self.presentable_phrase_group_ansi(list_item.phrase_group)
@@ -308,10 +345,205 @@ class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
             )
         return items
 
+    # ---------------------------------------------------
+    # Manual line editing (in-place, with TextArea) 
+    # ---------------------------------------------------
+
+    def action_edit_current_line(self) -> None:
+        """Open a TextArea for editing the currently selected line."""
+        if self.is_editing:
+            return
+        if self.selected_index is None:
+            return
+        if self.find_active:
+            return
+
+        item = self.list_items[self.phrase_indices[self.selected_index]]
+
+        # Block editing of SectionItem
+        if isinstance(item, TextEditorSectionItem):
+            return
+
+        item_id = item.item_id
+        phrase_group = self.edit_session.get_phrase_group(item_id)
+        if phrase_group is None:
+            return
+
+        original_text = phrase_group.phrase_group.text
+
+        # Normalize \r\n / \r to \n before handing text to the TextArea widget.
+        # Pure \n round-trips through TextArea unchanged, but a *mixed*
+        # \r\n/\n string gets coalesced by the widget to all \r\n - so we
+        # normalize here and keep this same normalized value as the baseline
+        # for the change-detection comparison in action_confirm_edit, instead
+        # of re-reading the raw (un-normalized) phrase_group.text there.
+        original_text = app_text.normalize_line_terminators(original_text)
+        self._edit_original_text = original_text
+
+        # Remove the previous widget before creating the new one (avoids DuplicateIds)
+        if self.editor_widget:
+            self.editor_widget.remove()
+            self.editor_widget = None
+
+        self.editor_widget = BaseTextArea(
+            id="edit-area",
+            text=original_text,
+            theme="vscode_dark",
+        )
+        self.mount(self.editor_widget)
+
+        # Enter editing mode. Keep editing_index/selected_index untouched so
+        # the line being edited remains the one visually selected/highlighted.
+        self.is_editing = True
+        self.editing_index = self.selected_index
+
+        # Refresh the line to apply the "reverse" style to the edited line
+        self.refresh_line(self.editing_index)
+
+        # Disable the OptionList so it can't respond to clicks or keyboard
+        # navigation while editing is in progress.
+        option_list = self.query_one("#line-list", NonWrappingOptionList)
+        option_list.disabled = True
+        option_list.highlighted = self.selected_index
+
+        # Focus the TextArea last, to make sure it (and not the OptionList)
+        # ends up holding keyboard focus.
+        self.editor_widget.focus()
+
+        # Defer the scroll until after layout has been recalculated with the
+        # newly mounted TextArea taking up space, so the visible area used for
+        # the scroll calculation is accurate.
+        self.call_after_refresh(option_list.scroll_to_highlight, top=True)
+
+        self.update_header(list(_HEADER_LINES_EDITING))
+
+    def action_confirm_edit(self) -> None:
+        """Confirm the text edit by applying the changes to the edit session."""
+        if self.editor_widget is None or self.editing_index is None:
+            return
+
+        try:
+            self.query_one("#edit-area")
+        except Exception:
+            return
+
+        edited_text = self.editor_widget.text
+
+        item = self.list_items[self.phrase_indices[self.editing_index]]
+        if isinstance(item, TextEditorSectionItem):
+            return
+
+        item_id = item.item_id
+        phrase_group = self.edit_session.get_phrase_group(item_id)
+        if phrase_group is None:
+            return
+
+        # Use the same normalized baseline stored when the editor was opened,
+        # instead of re-reading phrase_group.phrase_group.text raw - keeps
+        # both sides of the comparison consistent with what the TextArea
+        # widget can actually preserve unchanged.
+        if self._edit_original_text is None:
+            return
+        original_text = self._edit_original_text
+
+        if edited_text == original_text:
+            # Text did not change, remove the widget and finish
+            self._end_edit()
+            return
+
+        result = self.edit_session.update_phrase_group_text(
+            item_id=item_id,
+            new_text=edited_text,
+        )
+
+        # Apply the mutation to update list_items and refresh the UI
+        self.apply_mutation_result(result)
+
+        if self.editor_widget:
+            self.editor_widget.remove()
+            self.editor_widget = None
+
+        self._end_edit()
+        self.refresh()
+
+    def action_cancel_edit(self) -> None:
+        """Cancel the text edit by discarding the changes."""
+        if self.editor_widget:
+            self.editor_widget.remove()
+            self.editor_widget = None
+        self._end_edit()
+
+    def check_action(
+        self, action: str, parameters: tuple[object, ...]
+    ) -> bool | None:
+        """Disable app-level bindings that would otherwise shadow in-editor keys.
+
+        With priority=True, these bindings would intercept keys unconditionally:
+        - "escape" -> "cancel_edit" would shadow the inherited "escape" ->
+        "quit_editor" binding from ContentTextualApp, preventing the TUI from
+        closing when not editing.
+        - "ctrl+a" -> "select_all" would prevent Ctrl+A from reaching the
+        focused TextArea. Note: Textual's TextArea binds Ctrl+A to
+        cursor_line_start by default (readline-style), not select-all, so we
+        explicitly call the TextArea's own select_all() here to get
+        VS Code-style "select all" behavior instead.
+        Also, "ctrl+a" behaves weirdly here. To make it work as commonly intended
+        ("selec all") is necessary to "ctrl+a" and then "ctrl+c" (only tested on Windows).
+
+        Returning False tells Textual to skip the binding, letting the key fall
+        through to the next candidate (e.g. the TextArea's own bindings).
+        """
+        if action == "cancel_edit" and not self.is_editing:
+            return False
+        if action == "select_all" and self.is_editing:
+            if self.editor_widget:
+                self.editor_widget.select_all()
+            return False
+        return True
+
+    def _end_edit(self) -> None:
+        """End editing the current line."""
+        if self.editor_widget:
+            self.editor_widget.remove()
+            self.editor_widget = None
+
+        previously_editing_index = self.editing_index
+        self.is_editing = False
+        self.editing_index = None
+        self._edit_original_text = None
+
+        # Refresh the line to remove the "reverse" style
+        if previously_editing_index is not None:
+            self.refresh_line(previously_editing_index)
+
+        # Re-enable the OptionList and restore focus/highlight to it.
+        try:
+            option_list = self.query_one("#line-list", NonWrappingOptionList)
+            option_list.disabled = False
+            if self.selected_index is not None:
+                option_list.highlighted = self.selected_index
+            self.set_focus(option_list)
+        except Exception:
+            pass
+
+        self.update_header(list(_HEADER_LINES_DEFAULT))
+
+    def on_key(self, event: events.Key) -> None:
+        """Prevent TextArea from consuming CTRL+ENTER/ESC/CTRL+F when in edit mode."""
+        if self.is_editing:
+            if event.key in ("ctrl+return", "ctrl+enter", "ctrl+j", "escape", "ctrl+f"):
+                event.prevent_default()
+                if event.key == "escape" and self.editor_widget:
+                    self.action_cancel_edit()
+                elif event.key in ("ctrl+return", "ctrl+enter", "ctrl+j") and self.editor_widget:
+                    self.action_confirm_edit()
+
+    # ---------------------------------------------------
+
     def action_delete_phrase_groups(self) -> None:
         """Delete phrase rows, or one section when it is the sole selected row."""
         edit_session = self.edit_session_or_none
-        if self.find_active or edit_session is None:
+        if self.is_editing or self.find_active or edit_session is None:
             return
         selected_items = [
             self.list_items[self.phrase_indices[index]]
@@ -335,7 +567,7 @@ class TextEditor(ContentTextualApp[EditorSaved | EditorSaveFailed]):
 
     def action_split_phrase_group(self) -> None:
         """Open a boundary chooser for exactly one selected phrase-group row."""
-        if self.find_active or self.edit_session_or_none is None:
+        if self.is_editing or self.find_active or self.edit_session_or_none is None:
             return
         phrase_items = [
             item


### PR DESCRIPTION
## Add in-place line editing to the Text Editor

### Summary

Adds manual line editing to `TextEditor`: users can now edit a phrase group's text directly within the TUI via an embedded `TextArea` widget, instead of only deleting/splitting existing lines. Includes a fix for a line-terminator normalization bug in the change-detection comparison, uncovered while building this feature.

### What's new

**In-place editing (`text_editor.py`)**
- New `e` binding opens a `TextArea` for the currently selected phrase group row, in place, with the row visually highlighted (`reverse` style) while editing.
- `Ctrl+Enter` confirms the edit; `Esc` cancels and discards it.
- The row list (`OptionList`) is disabled and unfocused while editing, so navigation/selection keys don't leak into the editor; find (`Ctrl+F`) and `Ctrl+A` are also guarded via `check_action` / `on_key` so they route to the `TextArea` correctly instead of being intercepted by app-level priority bindings.
- Editing a `TextEditorSectionItem` (section heading row) is blocked.

**Text mutation (`text_edit_session.py`)**
- New `TextEditSession.update_phrase_group_text(item_id, new_text)`: rebuilds a phrase group's `Phrase`s from freeform edited text.
  - Preserves the phrase group's `voice_index`.
  - Preserves user-typed line breaks (e.g. Shift+Enter) the same way automatic segmentation encodes them: as trailing `\n` characters on a `Phrase`'s text, not as separate empty-text phrases. Blank lines are folded onto the previous line instead of becoming their own phrase.
  - Recomputes each phrase's `Reason` from its own trailing line-break count (0 → `SENTENCE`, 1–2 → `PARAGRAPH`, 3+ → `SPACE_BREAK`), matching the convention `phrase_segmenter.py` uses. This means a phrase's *original* reason (e.g. `SECTION_BREAK` from an EPUB import) is intentionally not preserved across an edit — see docstring for rationale.
  - Enforces the project's `max_words_per_segment`: any resulting line exceeding the limit is split via the existing `PhraseSegmenter.long_phrase_to_phrases`, so manually edited text stays consistent with how automatic segmentation defines "one segment."

**Change-detection fix (`app_text.py`, `text_editor.py`)**
- New `app_text.normalize_line_terminators(text)`: converts `\r\n` and lone `\r` to `\n`.
- **Bug fixed:** `action_confirm_edit` compared the raw (un-normalized) stored text against the `TextArea`'s text to detect "no-op" edits. Manual testing of Textual's `TextArea` (29 round-trip cases, see below) showed it preserves pure `\n` and pure `\r\n` text exactly, but *coalesces* a string that already mixes both into all-`\r\n`. This could cause a phrase group whose stored text already mixes line terminators (e.g. from a mixed-origin import) to be falsely flagged as "changed" on confirm, even with zero user edits — triggering the generated-segments-will-be-deleted confirmation dialog for nothing.
- Fix: `original_text` is normalized once when the editor opens (`action_edit_current_line`), stored in `self._edit_original_text`, and that same normalized value is used as the baseline in `action_confirm_edit` — instead of re-reading the raw stored text there. `update_phrase_group_text` itself did not need changes.

**Binding guards (`content_textual_app.py`)**
- `action_open_find` and `action_select_all` now no-op while `is_editing` is true, since both are registered as `priority=True` bindings on the base class and would otherwise intercept keystrokes meant for the `TextArea` before it ever sees them.

### Design decisions / known limitations (intentionally left as-is)

- **Multiple `Phrase`s per `PhraseGroup` is expected**, not a bug: `max_words_per_segment` bounds each individual `Phrase`, not the phrase group as a whole. A long edited line naturally becomes several phrases within one phrase group (one editable row, one `voice_index`).
- **A single "word" with no internal whitespace bypasses the length limit.** `max_words_per_segment` is measured in word count; a several-thousand-character string with no spaces counts as one "word" and is never split, regardless of character length. This is a pre-existing property of the word-count-based limit, not introduced by this change. Confirmed via manual testing (pasting an unspaced block vs. the same text with spaces — only the latter split at the configured limit). Left unaddressed for now as a plausible-but-unlikely edge case (malformed paste); flagged here for future consideration (e.g. a character-length safety net in `long_phrase_to_phrases`).

### Testing

Added to `tests/test_text_editor.py`:

1. `test_edit_simple_line` — single-line edit without `\n`
2. `test_edit_multiline_text` — edit introducing multiple `\n`
3. `test_edit_cancel_with_escape` — Esc discards in-progress edit
4. `test_edit_confirming_empty_text` — confirming empty text doesn't crash/hang
5. `test_edit_blocked_on_section_item` — editing a section heading is blocked
6. `test_edit_creates_has_changes` — `has_changes` set after a real edit
7. `test_edit_preserves_voice_index` — `voice_index` preserved across edit
8. `test_edit_single_line_edit_receives_Reason_SENTENCE` — a no-line-break edit gets `Reason.SENTENCE` (recomputed, not preserved — see `update_phrase_group_text` docstring)
9. `test_edit_confirm_without_changes_is_noop` — confirming without touching the text registers no change
10. `test_edit_confirm_mixed_line_endings_is_noop` — regression test for the `\r\n`/`\n` coalescing bug: a phrase group whose stored text already mixes line terminators still confirms as a no-op

Also fixed a pre-existing bug in the shared test helper `edit_first_line_to`: it pressed `down` unconditionally before opening the editor, assuming selection always starts *before* the first row. Since the `OptionList` actually selects index 0 by default, this extra `down` silently moved selection to the *second* row in any multi-phrase-group project — masked in every other test because they all used single-phrase-group projects, where `down` at index 0 is a no-op. Removed the redundant press; docstring updated to state the assumption explicitly.

**Manual verification of `TextArea` round-trip behavior** (informed the fix above): a standalone script constructed `textual.widgets.TextArea` with 29 representative strings (pure `\n`, pure `\r\n`, mixed, trailing whitespace, empty, etc.) and compared `.text` before/after. Pure `\n` and pure `\r\n` round-tripped unchanged in all cases; only strings already mixing both terminators were coalesced to all-`\r\n`. This confirmed the bug's real trigger condition and scoped the fix to normalization-before-load rather than a larger refactor.

### Out of scope / pre-existing, unrelated failures

Left untouched, confirmed unrelated to this change:
- `test_edit_model_loads_only_after_initial_loading_view_draws` — intermittently flaky (timing-related, likely `call_after_refresh`/`pilot.pause()` race); passes on repeat runs; unrelated code path (initial loading view, not line editing).
- `test_multiple_sections_add_ordered_headers_and_global_phrase_ordinals`, `test_empty_untitled_section_omits_title_separator_and_shows_zero_lines` — pre-existing `"\n\n"` vs `"\n"` mismatch in `format_section_list_item` output; also reproduces in `test_content_textual_app.py`, `test_review_segments_editor.py`, `test_voice_line_editor.py`. Not touched by this PR.

### Files changed

- `tts_audiobook_tool/textual/text_editor.py`
- `tts_audiobook_tool/text_ops/text_edit_session.py`
- `tts_audiobook_tool/textual/content_textual_app.py`
- `tts_audiobook_tool/app_support/app_text.py`
- `tests/test_text_editor.py`